### PR TITLE
user-guide: Turn `ini` highlights into no-highlight

### DIFF
--- a/doc/user-guide/source/operations_configuration.rst
+++ b/doc/user-guide/source/operations_configuration.rst
@@ -15,7 +15,7 @@ chunk_size
 Tells the services how to split the data of each content before spreaing the
 chunks on RAWX services.
 
-.. code-block:: ini
+.. code-block:: text
 
     param_chunk_size=${UINT64}
 
@@ -26,7 +26,7 @@ option.state
 Set to `standalone` by default, the state tells which commands are accepted by
 oio-sds. A namespace in `standalone` mode
 
-.. code-block:: ini
+.. code-block:: text
 
     param_option.state=standalone|master|slave
 
@@ -38,7 +38,7 @@ WORM stands for *Write Once, Read Many (and delete never)* and is intended for
 backup namespaces on situations of asynchronous replication. False by default,
 when activated it forbids direct removal of any content, by regular clients.
 
-.. code-block:: ini
+.. code-block:: text
 
     param_option.worm=yes|true|on|no|false|off
 
@@ -46,7 +46,7 @@ when activated it forbids direct removal of any content, by regular clients.
 option.events-max-pending
 -------------------------
 
-.. code-block:: ini
+.. code-block:: text
 
     param_option.events-max-pending: 10000
 
@@ -54,7 +54,7 @@ option.events-max-pending
 option.$SRVTYPE.events-max-pending
 ----------------------------------
 
-.. code-block:: ini
+.. code-block:: text
 
     param_option.sqlx.events-max-pending=1000
     param_option.meta2.events-max-pending=1000
@@ -64,7 +64,7 @@ option.$SRVTYPE.events-max-pending
 option.events-buffer-delay
 --------------------------
 
-.. code-block:: ini
+.. code-block:: text
 
     param_option.meta1.events-buffer-delay=5
     param_option.meta2.events-buffer-delay=5
@@ -74,7 +74,7 @@ option.events-buffer-delay
 option.$SRVTYPE.events-buffer-delay
 -----------------------------------
 
-.. code-block:: ini
+.. code-block:: text
 
     param_option.meta1.events-buffer-delay=5
     param_option.meta2.events-buffer-delay=5
@@ -84,7 +84,7 @@ option.$SRVTYPE.events-buffer-delay
 option.service_update_policy
 ----------------------------
 
-.. code-block:: ini
+.. code-block:: text
 
     param_option.service_update_policy=($SRVTYPE=(KEEP|APPEND|REPLACE)|$COUNT|$DISTANCE[|user_is_a_service=$SRVTYPE])+
 
@@ -92,7 +92,7 @@ option.service_update_policy
 option.meta2_max_versions
 -------------------------
 
-.. code-block:: ini
+.. code-block:: text
 
     param_option.meta2_max_versions=-1|0|$UINT64
 
@@ -100,7 +100,7 @@ option.meta2_max_versions
 option.meta2_keep_deleted_delay
 -------------------------------
 
-.. code-block:: ini
+.. code-block:: text
 
     param_option.meta2_keep_deleted_delay=$SECONDS
 
@@ -108,7 +108,7 @@ option.meta2_keep_deleted_delay
 option.container_max_size
 -------------------------
 
-.. code-block:: ini
+.. code-block:: text
 
     param_option.container_max_size=$BYTES
 
@@ -116,7 +116,7 @@ option.container_max_size
 option.flat_bitlength
 ---------------------
 
-.. code-block:: ini
+.. code-block:: text
 
     param_option.flatbitlength=16
 
@@ -127,7 +127,7 @@ option.storage_policy
 No default value, at least `SINGLE` is alway recognized as a single copy that
 will target `rawx` services.
 
-.. code-block:: ini
+.. code-block:: text
 
     option.storage_policy=$POLICY_NAME
 
@@ -135,7 +135,7 @@ will target `rawx` services.
 Obsolete namespace-wide / global options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. code-block:: ini
+.. code-block:: text
 
     option.flat_hash_offset=$UINT
     option.flat_hash_size=$UINT
@@ -155,7 +155,7 @@ proxy
 Tells the client SDK where is the `oio-proxy` to be used, as the primary
 endpoint to the namespace.
 
-.. code-block:: ini
+.. code-block:: text
 
     proxy=IP:PORT
 
@@ -166,7 +166,7 @@ conscience
 Tells the `oio-proxy` (and only the proxy) where is the `conscience` central
 service to be used.
 
-.. code-block:: ini
+.. code-block:: text
 
     conscience=IP:PORT[,IP:PORT]*
 
@@ -177,7 +177,7 @@ zookeeper
 Tells all the sqlitrepo-based service to connection string to be used to connect
 the Zookeeper cluster. Are concerned the meta0, meta1, meta2 and sqlx services.
 
-.. code-block:: ini
+.. code-block:: text
 
     zookeeper=IP:PORT[,IP:PORT]*
 
@@ -190,7 +190,7 @@ particuler service type into its own Zookeeper. E.g. because it is too critical
 or space consuming. The `zookeeper.$SRVTYPE` is dedicated to override the global
 `zookeeper` configuration.
 
-.. code-block:: ini
+.. code-block:: text
 
     zookeeper.meta0=IP:PORT
     zookeeper.meta1=IP:PORT
@@ -203,7 +203,7 @@ proxy-local
 When it is necessary to make the C SDK use local sockets to the local proxy,
 this is the parameter to be configured.
 
-.. code-block:: ini
+.. code-block:: text
 
     proxy-local=/path/to/proxy.sock
 
@@ -214,7 +214,7 @@ ecd
 Tells the client SDK where is the `erasure code daemon` that will manage the
 complex task of computing the erasure code on the data.
 
-.. code-block:: ini
+.. code-block:: text
 
     ecd=IP:PORT
 
@@ -228,7 +228,7 @@ is `beanstalkd` (and is identified by `beanstalkd://` endpoints), and the other
 is a ZeroMQ Request/Reply service (identified by `ipc://` and `tcp://`
 endpoints).
 
-.. code-block:: ini
+.. code-block:: text
 
     # Configuration usiing beanstalkd
     event-agent=beanstalk://IP:PORT
@@ -244,7 +244,7 @@ Set to `false` by default. When it is actived the services generated an outgoing
 access log, for both UDP and TCP messages. Be careful, The generated log can
 grow rapidly!
 
-.. code-block:: ini
+.. code-block:: text
 
     log_outgoing=yes|true|on|no|false|off
 
@@ -256,7 +256,7 @@ Turned off by default, this option is only considered by the `proxy`, `meta2`,
 network errors that occured when contacting `gridd` services. When the number of
 errors during the reference period.
 
-.. code-block:: ini
+.. code-block:: text
 
     avoid_faulty_services=yes|true|on|no|false|off
 
@@ -270,7 +270,7 @@ Using UDP on the client side will hide connection errors but save a lot of
 frames on the wire, save memory allocation (due to pending DB_USE requests that
 don't need to be queued), and save file descriptors.
 
-.. code-block:: ini
+.. code-block:: text
 
     udp_allowed=yes|true|on|no|false|off
 
@@ -281,7 +281,7 @@ Please refer to the section about the sizing considerations.
 
 Set to 4 as a default.
 
-.. code-block:: ini
+.. code-block:: text
 
     meta1_digits=0|1|2|3|4
 
@@ -290,7 +290,7 @@ zk_shuffled
 
 Don't use this option, it will be removed soon. It is turned down by default.
 
-.. code-block:: ini
+.. code-block:: text
 
     zk_shuffled=yes|true|on|no|false|off
 


### PR DESCRIPTION
... because not well managed, and we don't know why in the immediate term.