### PR TITLE
Fix invalid use of vars.export

### DIFF
--- a/tools/gen-vars.py
+++ b/tools/gen-vars.py
@@ -32,7 +32,7 @@ def main(out):
             name = conv(component + '_' + k)
             value = vals[v]
 
-            print("{0}={1}".format(name, value), file=out)
+            print("export {0}={1}".format(name, value), file=out)
         print(file=out)
 
 


### PR DESCRIPTION
Env variables has got invalid scope and was not exposed to children process.